### PR TITLE
Fix warning from numpy 1.17.

### DIFF
--- a/dcimg.py
+++ b/dcimg.py
@@ -75,7 +75,7 @@ file_name=input_file.dcimg>
         ('ysize', '<u4'),
         ('bytes_per_img', '<u4'),
         ('skip3', '2<u4'),
-        ('offset_to_data', '1<u4'),
+        ('offset_to_data', '<u4'),
         ('session_data_size', '<u8'),  # header_size + x*y*byte_depth*nfrms
     ]
 


### PR DESCRIPTION
Right now opening a file leads to

    FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
    self._sess_header = np.zeros(1, dtype=sess_dtype)
    FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
    dtype=sess_dtype)

Fix that.