### PR TITLE
Expose framestamps.

### DIFF
--- a/dcimg.py
+++ b/dcimg.py
@@ -285,6 +285,9 @@ file_name=input_file.dcimg>
 
         if self.fmt_version == DCIMGFile.FMT_OLD:
             # timestamp offset
+            offset = int(self._session_footer_offset + 272)
+            self._fs_data = np.ndarray(
+                (self.nfrms), np.uint32, self.mm, offset)
             offset = int(self._session_footer_offset + 272 + 4 * self.nfrms)
             self._ts_data = np.ndarray(
                 (self.nfrms, 2), np.uint32, self.mm, offset)
@@ -499,6 +502,16 @@ file_name=input_file.dcimg>
             a.shape = old_shape
 
         return a
+
+    def framestamps(self):
+        """Get framestamps.
+
+        Returns
+        -------
+        `numpy.ndarray`
+            A numpy array of dtype `numpy.uint32` with framestamps.
+        """
+        return self._fs_data
 
     def timestamps(self):
         """Get frame timestamps.


### PR DESCRIPTION
On old-format dcimg files, framestamp data appears to come immediately
before timestamp data; this also makes sense as that explains the
"272+4*nfrms" offset for timestamps.  I don't have new-format dcimg
files available for testing, so can't tell where they store their
framestamp data.

The API is a framestamps() method for consistency with timestamps(),
though both could be turned into properties.