### PR TITLE
Correctly set strides for old format.

### DIFF
--- a/dcimg.py
+++ b/dcimg.py
@@ -259,21 +259,18 @@ file_name=input_file.dcimg>
             self.close()
             raise
 
+        bd = self.byte_depth
         if self.fmt_version == self.FMT_OLD:
             offset = (self._session_footer_offset + 272
                       + self.nfrms * (4 + 8))  # 4: frame count, 8: timestamp
-            self._4px = np.ndarray((self.nfrms, 4), self.dtype, self.mm, offset)
-
-        offset = int(self._file_header['header_size']
-                     + self._sess_header['offset_to_data'][0])
-        strides = None
-        if self.fmt_version == self.FMT_NEW:
-            bd = self.byte_depth
+            self._4px = np.ndarray(
+                (self.nfrms, 4), self.dtype, self.mm, offset)
+            strides = (self.bytes_per_img, bd, self.bytes_per_row)
+        elif self.fmt_version == self.FMT_NEW:
             strides = (self.bytes_per_img + 32, bd)
             self._4px = np.ndarray((self.nfrms, 4), self.dtype, self.mm,
                                    offset + self.bytes_per_img + 12,
                                    strides)
-
             padding = self.bytes_per_img - self.xsize * self.ysize * bd
             padding //= self.ysize
             strides = [
@@ -282,6 +279,8 @@ file_name=input_file.dcimg>
                 1 * bd
             ]
             strides[0] += 32
+        offset = int(self._file_header['header_size']
+                     + self._sess_header['offset_to_data'][0])
         self.mma = np.ndarray(self.shape, self.dtype, self.mm, offset, strides)
 
         if self.fmt_version == DCIMGFile.FMT_OLD:


### PR DESCRIPTION
For cropped field of views and old-format dcimgs, the strides are
incorrect: they should be set using the "bytes_per_row" field.  This PR
fixes this issue.

As an additional note, it appears that the images returned by dcimg are
transposed by 90°, assuming that the notion of "row" should indeed be
horizontal.  (This shows up as the "weird" stride values.)  This could
be fixed in a later PR.